### PR TITLE
backend: sync table names with frontend for spdx_entities

### DIFF
--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/AnnotationEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/AnnotationEntity.java
@@ -21,6 +21,7 @@ package eu.occtet.boc.entity.spdxV2;
 import jakarta.persistence.*;
 
 @Entity
+@Table(name ="ANNOTATION_ENTITY")
 public class AnnotationEntity {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ChecksumEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ChecksumEntity.java
@@ -21,6 +21,7 @@ package eu.occtet.boc.entity.spdxV2;
 import jakarta.persistence.*;
 
 @Entity
+@Table(name = "CHECKSUM_ENTITY")
 public class ChecksumEntity {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/CreationInfoEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/CreationInfoEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import java.util.List;
 
 @Entity
+@Table(name = "CREATION_INFO_ENTITY")
 public class CreationInfoEntity {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ExternalDocumentRefEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ExternalDocumentRefEntity.java
@@ -21,6 +21,7 @@ package eu.occtet.boc.entity.spdxV2;
 import jakarta.persistence.*;
 
 @Entity
+@Table(name = "EXTERNAL_REF_DOCUMENT_ENTITY")
 public class ExternalDocumentRefEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ExternalRefEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ExternalRefEntity.java
@@ -21,6 +21,7 @@ package eu.occtet.boc.entity.spdxV2;
 import jakarta.persistence.*;
 
 @Entity
+@Table(name = "EXTERNAL_REF_ENTITY")
 public class ExternalRefEntity {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ExtractedLicensingInfoEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/ExtractedLicensingInfoEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import java.util.List;
 
 @Entity
+@Table(name = "EXTRACTED_LICENSING_INFO_ENTITY")
 public class ExtractedLicensingInfoEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/RelationshipEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/RelationshipEntity.java
@@ -21,6 +21,7 @@ package eu.occtet.boc.entity.spdxV2;
 import jakarta.persistence.*;
 
 @Entity
+@Table(name = "RELATIONSHIP_ENTITY")
 public class RelationshipEntity {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/SpdxDocumentRoot.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/SpdxDocumentRoot.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "SPDX_DOCUMENT_ROOT")
 public class SpdxDocumentRoot {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/SpdxFileEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/SpdxFileEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import java.util.List;
 
 @Entity
+@Table(name ="SPDX_FILE_ENTITY")
 public class SpdxFileEntity {
 
     @Id

--- a/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/SpdxPackageEntity.java
+++ b/occtet-nats/occtet-common-jpa/src/main/java/eu/occtet/boc/entity/spdxV2/SpdxPackageEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import java.util.List;
 
 @Entity
+@Table(name = "SPDX_PACKAGE_ENTITY")
 public class SpdxPackageEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
adjusted table names to be the same across occtet-common-jpa enteties and frontend tables.xml