### PR TITLE
Fix vulnerability detail

### DIFF
--- a/occtet-frontend/src/main/java/eu/occtet/bocfrontend/view/vulnerability/VulnerabilityDetailView.java
+++ b/occtet-frontend/src/main/java/eu/occtet/bocfrontend/view/vulnerability/VulnerabilityDetailView.java
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
-
 package eu.occtet.bocfrontend.view.vulnerability;
 
 
+import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
@@ -42,9 +42,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Route(value = "vulnerability/:id", layout = MainView.class)
@@ -55,6 +53,7 @@ public class VulnerabilityDetailView extends StandardDetailView<Vulnerability> {
 
     private static final Logger log = LogManager.getLogger(VulnerabilityDetailView.class);
 
+    private List<InventoryItem> allInventoryItems;
 
     @ViewComponent
     private TextArea aliasesField;
@@ -89,7 +88,11 @@ public class VulnerabilityDetailView extends StandardDetailView<Vulnerability> {
     @Subscribe
     public void onBeforeShow(BeforeShowEvent event) {
         Vulnerability vuln = getEditedEntity();
-        created.setText(vuln.getCreatedAt().format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")).toString());
+
+        if (vuln.getCreatedAt() != null) {
+            created.setText(vuln.getCreatedAt().format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")));
+        }
+
         aliasesField.setValue(
                 (vuln.getAliases() == null || vuln.getAliases().isEmpty())
                         ? ""
@@ -108,17 +111,51 @@ public class VulnerabilityDetailView extends StandardDetailView<Vulnerability> {
         );
 
         List<SoftwareComponent> softwareComponents = softwareComponentRepository.findByVulnerability(vuln);
-        softwareComboBox.setItems(softwareComponents);
+        softwareComboBox.setItems(softwareComponents.stream()
+                .distinct()
+                .collect(Collectors.toList()));
         softwareComboBox.setItemLabelGenerator(SoftwareComponent::getName);
-        List<InventoryItem> inventoryItems = inventoryItemRepository.findBySoftwareComponentIn(softwareComponents);
-        inventoryItemsDc.setItems(inventoryItems);
-        log.debug("found {} findings for vulnerability {}", inventoryItems.size(), getEditedEntity().getVulnerabilityId());
-        List<Project> projects = inventoryItems.stream().map(InventoryItem::getProject).collect(Collectors.toList());
+
+        // Fetch all inventory items (Findings)
+        allInventoryItems = inventoryItemRepository.findBySoftwareComponentIn(softwareComponents);
+        log.debug("found {} findings for vulnerability {}", allInventoryItems.size(), getEditedEntity().getVulnerabilityId());
+
+        // Populate Projects (Deduplicated)
+        List<Project> projects = allInventoryItems.stream()
+                .map(InventoryItem::getProject)
+                .distinct()
+                .collect(Collectors.toList());
         projectComboBox.setItems(projects);
         projectComboBox.setItemLabelGenerator(Project::getProjectName);
 
+        filterInventoryItems();
     }
 
+    @Subscribe("projectComboBox")
+    public void onProjectComboBoxComponentValueChange(AbstractField.ComponentValueChangeEvent<JmixComboBox<Project>, Project> event) {
+        filterInventoryItems();
+    }
+
+    @Subscribe("softwareComboBox")
+    public void onSoftwareComboBoxComponentValueChange(AbstractField.ComponentValueChangeEvent<JmixComboBox<SoftwareComponent>, SoftwareComponent> event) {
+        filterInventoryItems();
+    }
+
+    private void filterInventoryItems() {
+        if (allInventoryItems == null) {
+            return;
+        }
+
+        Project selectedProject = projectComboBox.getValue();
+        SoftwareComponent selectedComponent = softwareComboBox.getValue();
+
+        List<InventoryItem> filteredItems = allInventoryItems.stream()
+                .filter(item -> selectedProject == null || item.getProject().equals(selectedProject))
+                .filter(item -> selectedComponent == null || item.getSoftwareComponent().equals(selectedComponent))
+                .collect(Collectors.toList());
+
+        inventoryItemsDc.setItems(filteredItems);
+    }
 
     @Supply(to = "inventoryItemsDataGrid.fixedCheckBox", subject = "renderer")
     protected Renderer<InventoryItem> fixedCheckBoxRenderer(){

--- a/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/view/vulnerability/vulnerability-detail-view.xml
+++ b/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/view/vulnerability/vulnerability-detail-view.xml
@@ -82,7 +82,7 @@
                 <vbox width="100%" height="100%">
                     <hbox>
                         <comboBox id="projectComboBox" label="Project"/>
-                        <comboBox id="softwareComboBox" label="SoftwareComponent"/>
+                        <comboBox id="softwareComboBox" label="Software Component"/>
                     </hbox>
                     <dataGrid classNames="occtet-grid" id="inventoryItemsDataGrid"
                               width="100%"


### PR DESCRIPTION
Vulnerability detail findings tab no longer shows duplicated projects and software components in the dropdown. 
When i values is selected the list gets filtered.