### PR TITLE
Fixed bug in dashboard view

### DIFF
--- a/occtet-frontend/src/main/java/eu/occtet/bocfrontend/view/dashboard/DashboardView.java
+++ b/occtet-frontend/src/main/java/eu/occtet/bocfrontend/view/dashboard/DashboardView.java
@@ -275,7 +275,7 @@ public class DashboardView extends StandardView {
             case noRisk -> {
                 return new ValueLoadContext()
                         .setQuery(new ValueLoadContext.Query("""
-                        select count(s) as sumRiskScore
+                        select count(distinct s) as sumRiskScore
                         from InventoryItem i
                         join i.softwareComponent s
                         join i.project p
@@ -300,7 +300,7 @@ public class DashboardView extends StandardView {
             case softwareRisk -> {
                 return new ValueLoadContext()
                         .setQuery(new ValueLoadContext.Query("""
-                        select count(s) as sumRiskScore
+                        select count(distinct s) as sumRiskScore
                         from InventoryItem i
                         join i.softwareComponent s
                         join s.vulnerabilities v

--- a/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_de.properties
+++ b/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_de.properties
@@ -126,7 +126,7 @@ eu.occtet.bocfrontend.view.curatortask/startImport=Start import
 eu.occtet.bocfrontend.view.curatortask/status=Status
 eu.occtet.bocfrontend.view.curatortask/stop=Stop
 
-eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Anzahl Softwarekomponenten in einer spezifischen Risikokategorie basierend auf vorhandenen Schwachstellen
+eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Anzahl der Softwarekomponenten in einer bestimmten Risikokategorie von Schwachstellen
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.riskScore=Risk Score
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.NoScore=No Score
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.severity=Weighted Severity

--- a/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_en.properties
+++ b/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_en.properties
@@ -126,7 +126,7 @@ eu.occtet.bocfrontend.view.curatortask/startImport=Start import
 eu.occtet.bocfrontend.view.curatortask/status=Status
 eu.occtet.bocfrontend.view.curatortask/stop=Stop
 
-eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Number of software components in a specific risk category depending on vulnerabilities
+eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Number of software components in a specific risk category of vulnerabilities
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.riskScore=Risk Score
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.NoScore=No Score
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.severity=Weighted Severity

--- a/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_es.properties
+++ b/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_es.properties
@@ -364,7 +364,7 @@ eu.occtet.bocfrontend.view.curatortask/startImport=Iniciar importación
 eu.occtet.bocfrontend.view.curatortask/status=Estado
 eu.occtet.bocfrontend.view.curatortask/stop=Detener
 
-eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Número de componentes de software en una categoría de riesgo específica según las vulnerabilidades
+eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Número de componentes de software en una categoría específica de vulnerabilidades de riesgo
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.riskScore=Puntuación de riesgo
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.NoScore=Sin puntuación
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.severity=Gravedad ponderada

--- a/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_fr.properties
+++ b/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_fr.properties
@@ -361,7 +361,7 @@ eu.occtet.bocfrontend.view.curatortask/startImport=Démarrer l'importation
 eu.occtet.bocfrontend.view.curatortask/status=Statut
 eu.occtet.bocfrontend.view.curatortask/stop=Arrêter
 
-eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Nombre de composants logiciels dans une catégorie de risque spécifique en fonction des vulnérabilités
+eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Nombre de composants logiciels dans une catégorie spécifique de vulnérabilités
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.riskScore=Score de risque
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.NoScore=Aucun score
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.severity=Gravité pondérée

--- a/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_it.properties
+++ b/occtet-frontend/src/main/resources/eu/occtet/bocfrontend/messages_it.properties
@@ -361,7 +361,7 @@ eu.occtet.bocfrontend.view.curatortask/startImport=Avvia importazione
 eu.occtet.bocfrontend.view.curatortask/status=Stato
 eu.occtet.bocfrontend.view.curatortask/stop=Arresta
 
-eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Numero di componenti software in una specifica categoria di rischio in base alle vulnerabilità
+eu.occtet.bocfrontend.view.dashboard/dashboardView.charts.softwareComponent.subtext=Numero di componenti software in una specifica categoria di rischio di vulnerabilità
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.riskScore=Punteggio di rischio
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.NoScore=Nessun punteggio
 eu.occtet.bocfrontend.view.dashboard/dashboardView.tooltip.severity=Gravità ponderata


### PR DESCRIPTION
The pie chart of software components in dashboard view: Does not show multiple instances of a software component in a specific risk category