### PR TITLE
Improve ORT Server Integration with Curator

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Build with Gradle
         run: |
           cd occtet-frontend
-          ./gradlew -Pvaadin.productionMode=true bootJar \
+          ./gradlew -Pvaadin.productionMode=true bootJar --refresh-dependencies \
             -PgithubUsername=${{ github.actor }} \
             -PgithubToken=${{ secrets.GITHUB_TOKEN }}
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -239,7 +239,8 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/occtet-frontend/src/main/java/eu/occtet/bocfrontend/config/ConfigOrtProperties.java
+++ b/occtet-frontend/src/main/java/eu/occtet/bocfrontend/config/ConfigOrtProperties.java
@@ -8,6 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record ConfigOrtProperties (
 
     String clientId,
+    String clientSecret,
     String tokenUrl,
     String username,
     String password,

--- a/occtet-frontend/src/main/java/eu/occtet/bocfrontend/ortTask/ProcessOrtRunTask.java
+++ b/occtet-frontend/src/main/java/eu/occtet/bocfrontend/ortTask/ProcessOrtRunTask.java
@@ -142,7 +142,7 @@ public class ProcessOrtRunTask  {
     private ApiClient getApiClient() {
         try {
             OrtClientService ortClientService = new OrtClientService(ortProperties.baseUrl(), cacertPath, ortProperties.tokenUrl(), ortProperties.clientId());
-            AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath);
+            AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath, ortProperties.clientSecret());
             log.info("connection with ORT on {}", ortProperties.baseUrl());
             log.info("connection URL {}", ortProperties.tokenUrl());
             TokenResponse tokenResponse = null;

--- a/occtet-frontend/src/main/java/eu/occtet/bocfrontend/ortTask/ProcessOrtRunTask.java
+++ b/occtet-frontend/src/main/java/eu/occtet/bocfrontend/ortTask/ProcessOrtRunTask.java
@@ -147,7 +147,7 @@ public class ProcessOrtRunTask  {
             log.info("connection URL {}", ortProperties.tokenUrl());
             TokenResponse tokenResponse = null;
 
-            tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "offline_access");
+            tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "openid");
 
 
             return ortClientService.createApiClient(tokenResponse);

--- a/occtet-frontend/src/main/resources/application-live.properties
+++ b/occtet-frontend/src/main/resources/application-live.properties
@@ -46,6 +46,7 @@ main.datasource.driver-class-name=org.postgresql.Driver
 
 # EXTERNAL SERVICES (ORT Server)
 ort.clientId=${ORT_CLIENT_ID:ort-server}
+ort.clientSecret=${ORT_CLIENT_SECRET}
 ort.tokenUrl=${ORT_TOKEN_URL}
 ort.baseURL=${ORT_BASE_URL}
 ort.username=${ORT_USERNAME}

--- a/occtet-frontend/src/main/resources/application-oidc.properties
+++ b/occtet-frontend/src/main/resources/application-oidc.properties
@@ -46,6 +46,7 @@ main.datasource.driver-class-name=org.postgresql.Driver
 
 # EXTERNAL SERVICES (ORT Server)
 ort.clientId=${ORT_CLIENT_ID:ort-server}
+ort.clientSecret=${ORT_CLIENT_SECRET}
 ort.tokenUrl=${ORT_TOKEN_URL}
 ort.baseURL=${ORT_BASE_URL}
 ort.username=${ORT_USERNAME}

--- a/occtet-nats/occtet-nats-ai-copyrightfilter-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-ai-copyrightfilter-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
             <appender-ref ref="STDOUT" />

--- a/occtet-nats/occtet-nats-ai-licensematcher-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-ai-licensematcher-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="STDOUT" />
             <appender-ref ref="DB" />

--- a/occtet-nats/occtet-nats-copyrightfilter-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-copyrightfilter-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-nats-cyclonedx-export-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-cyclonedx-export-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-nats-cyclonedx-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-cyclonedx-service/src/main/resources/logback-spring.xml
@@ -26,16 +26,6 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
         <root level="info">
             <!--appender-ref ref="DB" /-->

--- a/occtet-nats/occtet-nats-download-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-download-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
             <appender-ref ref="STDOUT" />

--- a/occtet-nats/occtet-nats-foss-report-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-foss-report-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-nats-licensematcher-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-licensematcher-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/config/ConfigOrtProperties.java
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/config/ConfigOrtProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record ConfigOrtProperties(
 
     String clientId,
+    String clientSecret,
     String tokenUrl,
     String username,
     String password,

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
@@ -142,6 +142,7 @@ public class ORTRunStarterService {
                 log.debug("Organization {} not found, creating it", orgaName);
                 PostOrganization po = new PostOrganization();
                 po.setName(orgaName);
+                po.setDescription("");
                 orga = organizationsApi.postOrganization(po);
             } else {
                 log.debug("Organization {} found", orgaName);

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
@@ -78,6 +78,18 @@ public class ORTRunStarterService {
         log.info("authcall on keycloak with clientId {} username {} password {}", ortProperties.clientId(), ortProperties.username(), ortProperties.password().substring(0,2)+"..." );
 
         TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "offline_access");
+        // DEBUG - decode JWT payload to inspect claims
+        if (tokenResponse.accessToken != null) {
+            String[] parts = tokenResponse.accessToken.split("\\.");
+            if (parts.length >= 2) {
+                String payload = new String(java.util.Base64.getUrlDecoder().decode(
+                    parts[1].length() % 4 == 0 ? parts[1] : parts[1] + "=".repeat(4 - parts[1].length() % 4)
+                ));
+                log.info("DEBUG JWT payload: {}", payload);
+            }
+        } else {
+            log.warn("DEBUG accessToken is NULL in TokenResponse");
+        }
         ApiClient apiClient = ortClientService.createApiClient(tokenResponse);
 
         // how to access organizations api

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
@@ -77,7 +77,7 @@ public class ORTRunStarterService {
         AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath, ortProperties.clientSecret());
         log.info("authcall on keycloak with clientId {} username {} password {}", ortProperties.clientId(), ortProperties.username(), ortProperties.password().substring(0,2)+"..." );
 
-        TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "offline_access");
+        TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "openid");
         // DEBUG - decode JWT payload to inspect claims
         if (tokenResponse.accessToken != null) {
             String[] parts = tokenResponse.accessToken.split("\\.");

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
@@ -142,7 +142,7 @@ public class ORTRunStarterService {
                 log.debug("Organization {} not found, creating it", orgaName);
                 PostOrganization po = new PostOrganization();
                 po.setName(orgaName);
-                po.setDescription("");
+                po.setDescription(orgaName);
                 orga = organizationsApi.postOrganization(po);
             } else {
                 log.debug("Organization {} found", orgaName);

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/java/eu/occtet/boc/ortrunstart/service/ORTRunStarterService.java
@@ -74,7 +74,7 @@ public class ORTRunStarterService {
         String orgaName= project.getOrganization().getOrganizationName();
         log.info("connection with ORT on {}, add. cacerts from {}", ortProperties.baseUrl(), cacertPath);
         OrtClientService ortClientService = new OrtClientService(ortProperties.baseUrl(), cacertPath, ortProperties.tokenUrl(), ortProperties.clientId());
-        AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath);
+        AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath, ortProperties.clientSecret());
         log.info("authcall on keycloak with clientId {} username {} password {}", ortProperties.clientId(), ortProperties.username(), ortProperties.password().substring(0,2)+"..." );
 
         TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "offline_access");

--- a/occtet-nats/occtet-nats-ort-run-start-service/src/main/resources/application-live.properties
+++ b/occtet-nats/occtet-nats-ort-run-start-service/src/main/resources/application-live.properties
@@ -23,6 +23,7 @@ spring.config.import=classpath:application-common-live.properties
 # ORT CONNECTION (Production)
 # Strictly injected via environment variables
 ort.clientId=${ORT_CLIENT_ID:ort-server}
+ort.clientSecret=${ORT_CLIENT_SECRET}
 ort.tokenUrl=${ORT_TOKEN_URL}
 ort.baseURL=${ORT_BASE_URL}
 ort.username=${ORT_USERNAME}

--- a/occtet-nats/occtet-nats-process-run-service/src/main/java/eu/occtet/boc/processRun/config/ConfigOrtProperties.java
+++ b/occtet-nats/occtet-nats-process-run-service/src/main/java/eu/occtet/boc/processRun/config/ConfigOrtProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record ConfigOrtProperties(
 
     String clientId,
+    String clientSecret,
     String tokenUrl,
     String username,
     String password,

--- a/occtet-nats/occtet-nats-process-run-service/src/main/java/eu/occtet/boc/processRun/service/ProcessRunService.java
+++ b/occtet-nats/occtet-nats-process-run-service/src/main/java/eu/occtet/boc/processRun/service/ProcessRunService.java
@@ -97,7 +97,7 @@ public class ProcessRunService {
         log.debug("Start processing run with id {}", runId);
 
         OrtClientService ortClientService = new OrtClientService(ortProperties.baseUrl(), cacertPath, ortProperties.tokenUrl(), ortProperties.clientId());
-        AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath);
+        AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath, ortProperties.clientSecret());
 
         TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "offline_access");
         ApiClient apiClient = ortClientService.createApiClient(tokenResponse);

--- a/occtet-nats/occtet-nats-process-run-service/src/main/java/eu/occtet/boc/processRun/service/ProcessRunService.java
+++ b/occtet-nats/occtet-nats-process-run-service/src/main/java/eu/occtet/boc/processRun/service/ProcessRunService.java
@@ -99,7 +99,7 @@ public class ProcessRunService {
         OrtClientService ortClientService = new OrtClientService(ortProperties.baseUrl(), cacertPath, ortProperties.tokenUrl(), ortProperties.clientId());
         AuthService authService = new AuthService(ortProperties.tokenUrl(), cacertPath, ortProperties.clientSecret());
 
-        TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "offline_access");
+        TokenResponse tokenResponse = authService.requestToken(ortProperties.clientId(), ortProperties.username(), ortProperties.password(), "openid");
         ApiClient apiClient = ortClientService.createApiClient(tokenResponse);
 
         RunsApi runsApi = new RunsApi(apiClient);

--- a/occtet-nats/occtet-nats-process-run-service/src/main/resources/application-live.properties
+++ b/occtet-nats/occtet-nats-process-run-service/src/main/resources/application-live.properties
@@ -23,6 +23,7 @@ spring.config.import=classpath:application-common-live.properties
 # ORT CONNECTION (Production)
 # Strictly injected via environment variables
 ort.clientId=${ORT_CLIENT_ID:ort-server}
+ort.clientSecret=${ORT_CLIENT_SECRET}
 ort.tokenUrl=${ORT_TOKEN_URL}
 ort.baseURL=${ORT_BASE_URL}
 ort.username=${ORT_USERNAME}

--- a/occtet-nats/occtet-nats-spdx-export-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-spdx-export-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-nats-spdx-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-spdx-service/src/main/resources/logback-spring.xml
@@ -26,16 +26,6 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
         <root level="info">
             <!--appender-ref ref="DB" /-->

--- a/occtet-nats/occtet-nats-template/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-template/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-nats-vulnerability-service/src/main/resources/logback-spring.xml
+++ b/occtet-nats/occtet-nats-vulnerability-service/src/main/resources/logback-spring.xml
@@ -26,17 +26,16 @@
             <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
-    <property resource="application-common-live.properties" />
-    <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
-        <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
-            <driverClass>org.postgresql.Driver</driverClass>
-            <url>${spring.datasource.url}</url>
-            <user>${spring.datasource.username}</user>
-            <password>${spring.datasource.password}</password>
-        </connectionSource>
-    </appender>
-
     <springProfile name="live">
+        <property resource="application-common-live.properties" />
+        <appender name="DB" class="ch.qos.logback.classic.db.DBAppender">
+            <connectionSource class="ch.qos.logback.core.db.DriverManagerConnectionSource">
+                <driverClass>org.postgresql.Driver</driverClass>
+                <url>${spring.datasource.url}</url>
+                <user>${spring.datasource.username}</user>
+                <password>${spring.datasource.password}</password>
+            </connectionSource>
+        </appender>
         <root level="error">
             <appender-ref ref="DB" />
         </root>

--- a/occtet-nats/occtet-ort-client/src/main/java/eu/occtet/boc/ortclient/AuthService.java
+++ b/occtet-nats/occtet-ort-client/src/main/java/eu/occtet/boc/ortclient/AuthService.java
@@ -49,6 +49,8 @@ public class AuthService {
 
     private String cacertPath;
 
+    private String clientSecret;
+
     private static final Logger log = LogManager.getLogger(AuthService.class);
 
 
@@ -59,6 +61,11 @@ public class AuthService {
     public AuthService(@Nonnull String tokenEndpointUrl, String cacertPath) {
         this.tokenEndpointUrl = tokenEndpointUrl;
         this.cacertPath= cacertPath;
+    }
+
+    public AuthService(@Nonnull String tokenEndpointUrl, String cacertPath, String clientSecret) {
+        this(tokenEndpointUrl, cacertPath);
+        this.clientSecret = clientSecret;
     }
 
 
@@ -97,7 +104,8 @@ public class AuthService {
                 "client_id", clientId,
                 "username", username,
                 "password", password,
-                scope != null ? "scope" : null, scope
+                scope != null ? "scope" : null, scope,
+                (clientSecret != null && !clientSecret.isEmpty()) ? "client_secret" : null, clientSecret
         );
 
         HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()

--- a/occtet-nats/occtet-ort-client/src/main/java/eu/occtet/boc/ortclient/OrtClientService.java
+++ b/occtet-nats/occtet-ort-client/src/main/java/eu/occtet/boc/ortclient/OrtClientService.java
@@ -43,7 +43,7 @@ public class OrtClientService {
     private String ortBaseUrl;
     private String keycloakTokenUrl;
     private String clientId;
-    private String scope="offline_access";
+    private String scope="openid";
     private String cacertPath;
 
 

--- a/occtet-nats/occtet-ort-client/src/main/resources/openapi.json
+++ b/occtet-nats/occtet-ort-client/src/main/resources/openapi.json
@@ -11145,6 +11145,10 @@
             }, {
               "$ref" : "#/components/schemas/UserDisplayName"
             } ]
+          },
+          "ortServerVersion" : {
+            "type" : [ "null", "string" ],
+            "title" : "String"
           }
         },
         "required" : [ "createdAt", "id", "index", "jobs", "labels", "organizationId", "productId", "repositoryId", "revision", "status" ],


### PR DESCRIPTION
This PR integrates ORT Server with Curator and completes the authentication, deployment, and API client changes required to trigger and monitor ORT analysis runs.

Changes

- Propagate the ORT client secret to the Curator deployment.
- Configure Curator deployments for pull request environments.
- Update the OIDC configuration:
- use the openid scope;
- remove the unsupported offline_access scope;
- improve logging to troubleshoot token subject claims.
- Improve ORT Server startup by handling null run descriptions.
- Use the organization name as the default run description when no description is provided.
- Fix the logging appender configuration for the live environment.
- Add the missing ortServerVersion field to the OrtRunSummary OpenAPI schema.
- Refresh dependencies when building the occtet-ort-client JAR.


These changes allow Curator to authenticate with ORT Server, create analysis runs, and consume the updated ORT Server API.

/cc @Lelalue 